### PR TITLE
Autoload namespace typo fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     },
     "autoload": {
         "psr-4": {
-            "PCApredict\\Tag\\": ""
+            "PCAPredict\\Tag\\": ""
         },        
         "files": [
             "registration.php"


### PR DESCRIPTION
Capitalisation of Predict needed to be changed in order to work on case-sensitive systems.
