### PR TITLE
various fixes, see release-notes.md

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,18 +3,20 @@
     "description": "Address, Email and Phone Validation for Checkout Forms",
     "require": {
         "php": "~5.5.0|~5.6.0|~7.0.0",
-        "magento/magento-composer-installer": "*"
+        "magento/framework": "*",
+        "magento/magento-composer-installer": "*",
+        "magento/module-store": "*"
     },
     "autoload": {
         "psr-4": {
             "PCAPredict\\Tag\\": ""
-        },        
+        },
         "files": [
             "registration.php"
         ]
     },
     "type": "magento2-module",
-    "version": "1.0.1",
+    "version": "1.0.3",
     "authors": [
         {
             "name": "PCA Predict",

--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -2,10 +2,10 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
     <acl>
         <resources>
-            <resource id="Magento_Adminhtml::admin">
-                <resource id="Magento_Adminhtml::stores">
-                    <resource id="Magento_Adminhtml::stores_settings">
-                        <resource id="Magento_Adminhtml::config">
+            <resource id="Magento_Backend::admin">
+                <resource id="Magento_Backend::stores">
+                    <resource id="Magento_Backend::stores_settings">
+                        <resource id="Magento_Config::config">
                             <resource id="PCAPredict_Tag::configuration" title="PCA Predict Tag" />
                         </resource>
                     </resource>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0"?>
-<config>
-   <module name="PCAPredict_Tag" setup_version="1.0.2"></module>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="PCAPredict_Tag" setup_version="1.0.3">
+        <sequence>
+            <module name="Magento_Store"/>
+        </sequence>
+    </module>
 </config>

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,0 +1,21 @@
+# Release notes
+
+## v1.0.3
+
+- Fix mismatching versions (`composer.json` declares v1.0.1 in tagged 1.0.2)
+- Fix [critical bug that breaks ACL rendering](https://github.com/magento/magento2/pull/4396)
+- Update `etc/module.xml` to use XML namespace and convention
+- Update requirements of other modules (previously undeclared)
+- Upgrade release notes to Markdown
+
+## v1.0.2
+
+- Fix typo in composer.json
+
+## v1.0.1
+
+- Fix issue where address fields are not detecting changes when populating from search results
+
+## v1.0.0
+
+Initial release.

--- a/release-notes.txt
+++ b/release-notes.txt
@@ -1,8 +1,0 @@
-=== v1.0.2 ===
-Fix typo in composer.json
-
-=== v1.0.1 ===
-Fix issue where address fields are not detecting changes when populating from search results
-
-=== v1.0.0 ===
-Initial release


### PR DESCRIPTION
Please see `release-notes.md` for full detail. This fixes a critical bug that affects ACL and a composer issue (in that the tagged 1.0.2 has the wrong version number in `composer.json`).
