### PR TITLE
Fix settings fail to save

### DIFF
--- a/view/adminhtml/templates/tag_settings_index_script.phtml
+++ b/view/adminhtml/templates/tag_settings_index_script.phtml
@@ -1,4 +1,5 @@
 <?php
+/** @var $block \Magento\Backend\Block\Template */
 
 $pcaSettings = $this->helper('PCAPredict\Tag\Helper\SettingsData');
 $pcaAccCode = $pcaSettings->getAccountCode();
@@ -166,7 +167,7 @@ $pcaCustomJSBack = $pcaSettings->getCustomJavaScriptBack();
                     $('#btnSave').addClass('working');  
                     $.ajax({
                         type: 'POST',
-                        url: 'tag/settings', 
+                        url: '<?php echo $block->getUrl('tag/settings'); ?>',
                         showLoader: true,                  
                         data: { 
                             "form_key": window.FORM_KEY,
@@ -322,7 +323,7 @@ $pcaCustomJSBack = $pcaSettings->getCustomJavaScriptBack();
 
                     $.ajax({
                         type: 'POST',
-                        url: 'tag/settings',
+                        url: '<?php echo $block->getUrl('tag/settings'); ?>',
                         showLoader: true,                    
                         data: { 
                             "form_key": window.FORM_KEY,


### PR DESCRIPTION
# Issue

Settings fail to save on: https://magento-site.dev/admin/tag/settings due to incorrect endpoint route

![incorrect-endpoint](https://cloud.githubusercontent.com/assets/945819/25656998/9266a618-2ff3-11e7-8669-05414653c75d.png)

```diff
- /tag/tag/settings/?isAjax=true
+/tag/settings/?isAjax=true
```

# Bug Reproduction

1. Go to `admin/tag/settings/`
2. Modify settings
3. Click save
4. Refresh

**Expected Result:**

New settings are saved

**Actual Result:**

Settings fail to save