### PR TITLE
Fix "order is not defined" error

### DIFF
--- a/view/adminhtml/templates/sales_order_create_customer_block_script.phtml
+++ b/view/adminhtml/templates/sales_order_create_customer_block_script.phtml
@@ -13,7 +13,7 @@
     d.async = !0; d.src = e; c = c.getElementsByTagName("script")[0]; c.parentNode.insertBefore(d, c)
     })(window, document, "pca", "/" + "/<?php echo $pcaAccCode; ?>.pcapredict.com/js/sensor.js");
 
-    requirejs(['jquery'], function(){
+    requirejs(['jquery', 'Magento_Sales/order/create/form'], function(){
 
         (function() {
 


### PR DESCRIPTION
When creating new order we are getting "order is not defined" error in inspector console

![Image of bug](https://image.prntscr.com/image/IG-x5IjaThSOFBLHfgmjcw.png)

**Tech**

This errors appears when order we are trying to access order object before initialization in form.js
Adding form.js script as part of requirements

**Prerequisites**

1. Magento 2.2
2. Chrome browser build 63.0.3239.84

**Steps to reproduce**

1. Install extension and enter credentials of your account
2. Flush cache
3. Create new order
4. Check inspector console

