### PR TITLE
Fix for broken checkout in Magento 2.2 due to layout attribute in XML

### DIFF
--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="checkout" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="head.additional">
             <block class="Magento\Framework\View\Element\Template" name="pcapredict.tag.script_checkout" template="PCAPredict_Tag::checkout_index_index.phtml" />


### PR DESCRIPTION
I'm finding a broken checkout in 2.2 and after removing this layout attribute in checkout_index_index.xml the issue goes away.

I'd say it's bad practice to redefine what page_layout a controller of another module is using, unless it is done intentionally. In this case it is definitely not intentional.

I don't understand how this page_layout definition in the attribute breaks the checkout, but for me it 100% does.