### PR TITLE
Fix for invalid XML in layouts

### DIFF
--- a/view/adminhtml/layout/customer_index_edit.xml
+++ b/view/adminhtml/layout/customer_index_edit.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="js">

--- a/view/adminhtml/layout/sales_order_address.xml
+++ b/view/adminhtml/layout/sales_order_address.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="admin-1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="js">

--- a/view/adminhtml/layout/sales_order_create_customer_block.xml
+++ b/view/adminhtml/layout/sales_order_create_customer_block.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="admin-1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="js">

--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="head.additional">


### PR DESCRIPTION
While working on this pull request https://github.com/PCAPredict/magento2/pull/23 I stumbled on a bunch of instances where there is invalid XML. A bunch of layout files didn't have XML declarations and this PR addresses those.