### PR TITLE
Remove explicit version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
         ]
     },
     "type": "magento2-module",
-    "version": "2.0.9",
     "authors": [
         {
             "name": "PCA Predict",


### PR DESCRIPTION
Compare https://github.com/PCAPredict/magento2/tags with https://packagist.org/packages/pcapredict/tag and note that v2.1.0 exists in the former but not the latter.

Packagist.org will parse the git tag and use this as version. As git tag `v2.1.0` claims to also be version `2.0.9` (see https://github.com/PCAPredict/magento2/blob/v2.1.0/composer.json#L22), this version is not recognised by packagist. Removing the version string from `composer.json` will avoid this problem going forward.

Update: versions [`2.0.9`](https://github.com/PCAPredict/magento2/blob/v2.0.9/composer.json#L22) and [`2.0.9.1`](https://github.com/PCAPredict/magento2/blob/v2.0.9.1/composer.json#L22) are also unavailable for the same reason as stated above.

Fixes: #33
Fixes: #36
Replaces: #37