### PR TITLE
Deprecate this module in favour of new brand

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "pcapredict/tag",
     "description": "Address Validation for Checkout Forms",
+    "abandoned": "loqate/tag",
     "repositories": {
     "magento": {
             "type": "composer",


### PR DESCRIPTION
The support team tell me that this module is deprecated and should not be used any longer. Their new module is available via the Magento Marketplace here: https://marketplace.magento.com/catalog/product/view/id/256182/s/loqate-tag/